### PR TITLE
Enabling HS01 for usb c device

### DIFF
--- a/EFI/OC/Kexts/USBMap.kext/Contents/Info.plist
+++ b/EFI/OC/Kexts/USBMap.kext/Contents/Info.plist
@@ -42,6 +42,15 @@
 				</data>
 				<key>ports</key>
 				<dict>
+					<key>HS01</key>
+					<dict>
+						<key>UsbConnector</key>
+						<integer>3</integer>
+						<key>port</key>
+						<data>
+						AQAAAA==
+						</data>
+					</dict>
 					<key>HS02</key>
 					<dict>
 						<key>Comment</key>


### PR DESCRIPTION
adding support for usb c like external dvd writer or other usb c devices.