### PR TITLE
whatevergreen update

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -278,6 +278,8 @@
 				<data>mz4AAA==</data>
 				<key>dpcd-max-link-rate</key>
 				<data>CgAAAA==</data>
+				<key>enable-backlight-registers-fix</key>
+				<data>AQAAAA==</data>
 				<key>enable-dpcd-max-link-rate-fix</key>
 				<data>AQAAAA==</data>
 				<key>enable-hdmi20</key>
@@ -1242,7 +1244,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>-v debug=0x100 keepsyms=1</string>
+				<string>-v debug=0x100 keepsyms=1 -igfxblr </string>
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>csr-active-config</key>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1244,7 +1244,7 @@
 				<key>SystemAudioVolume</key>
 				<data>Rg==</data>
 				<key>boot-args</key>
-				<string>-v debug=0x100 keepsyms=1 -igfxblr </string>
+				<string>-v debug=0x100 keepsyms=1 </string>
 				<key>run-efi-updater</key>
 				<string>No</string>
 				<key>csr-active-config</key>


### PR DESCRIPTION
resolve the black screen with latest whatevergreen kext.
-igfxblr boot argument 
or  enable-backlight-registers-fix property
 to fix backlight registers on KBL, CFL and ICL platforms.